### PR TITLE
We can get the user's location by GPS or IP address. We default to GPS

### DIFF
--- a/src/App/index.tsx
+++ b/src/App/index.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react';
 import { CurrentConditions, Loading } from '../components';
 
 
-export default function App() {
+export default function App(): JSX.Element {
     return (
         <Suspense fallback={<Loading />}>
             <CurrentConditions />

--- a/src/components/CurrentConditions/index.tsx
+++ b/src/components/CurrentConditions/index.tsx
@@ -5,7 +5,7 @@ import { WeatherAPI, IApiResponse, IWeather, suspender } from '../../utils';
 // fetch our weather data
 const weatherData = suspender(WeatherAPI.getCurrentWeather({ full: true }));
 
-export default function CurrentConditions() {
+export default function CurrentConditions(): JSX.Element {
     const [isMounted, setIsMounted] = useState<null | boolean>(null);
     const resource: IApiResponse<IWeather> = weatherData.read();
 

--- a/src/utils/APIs/location/helpers.ts
+++ b/src/utils/APIs/location/helpers.ts
@@ -1,0 +1,74 @@
+export const fetchLocationBrowserAPI = async (): Promise<GeolocationPosition | null> => {
+    return new Promise((resolve, reject) => {
+        try {
+            navigator.geolocation.getCurrentPosition(
+                position => {
+                    resolve(position);
+                },
+                error => {
+                    reject(error);
+                }
+            );
+        } catch (error) {
+            console.log('USER DENIED LOCATION ACCESS', error);
+            reject(error);
+        }
+    });
+};
+
+export const fetchIp = async (): Promise<string | null> => {
+    try {
+        const response = await fetch('https://myexternalip.com/json');
+        const data = await response.json();
+        return data.ip;
+    } catch (error) {
+        console.log('Error fetching IP', error);
+        return null;
+    }
+};
+
+
+export const fetchGeoFromIp = async (ip: string): Promise<{ latitude: number, longitude: number } | null> => {
+    try {
+        const response = await fetch(`https://ipapi.co/${ip}/json/`);
+        const data = await response.json();
+
+        return { latitude: data.latitude, longitude: data.longitude };
+    } catch (error) {
+        console.log('Error fetching Geo from IP', error);
+        return null;
+    }
+};
+
+
+export async function getUserLocation() {
+    const userLocation = await fetchLocationBrowserAPI().catch(async _ => {
+        const IP = await fetchIp();
+
+        if (IP) {
+            const geo = await fetchGeoFromIp(IP);
+            if (geo) {
+                return {
+                    coords:
+                        { latitude: geo.latitude, longitude: geo.longitude }
+                } as GeolocationPosition;
+            }
+            else {
+                alert('Error getting your location. Please enable location services.');
+            }
+        }
+        else {
+            alert('Please enable location access or allow us to use your IP address to get your location');
+        }
+
+        return null;
+    });
+
+    const { coords } = userLocation || {
+        coords: {
+            latitude: 0, longitude: 0
+        }
+    } as GeolocationPosition;
+
+    return coords;
+}

--- a/src/utils/APIs/location/index.ts
+++ b/src/utils/APIs/location/index.ts
@@ -1,0 +1,8 @@
+import { getUserLocation } from './helpers';
+import { ILocationAPI } from './interface';
+
+const Location: ILocationAPI = {
+    getPosition: getUserLocation
+};
+
+export default Location;

--- a/src/utils/APIs/location/interface.ts
+++ b/src/utils/APIs/location/interface.ts
@@ -1,0 +1,3 @@
+export interface ILocationAPI {
+    getPosition: () => Promise<GeolocationCoordinates>;
+}

--- a/src/utils/APIs/weather/index.ts
+++ b/src/utils/APIs/weather/index.ts
@@ -1,5 +1,7 @@
+import { LocationAPI } from '../..';
 import { IApiResponse } from '../interfaces';
 import { IWeather, ICurrentWeatherProps } from './interfaces';
+
 
 
 class WeatherAPI {
@@ -13,9 +15,24 @@ class WeatherAPI {
 
     public async getCurrentWeather(props: ICurrentWeatherProps):
         Promise<IApiResponse<IWeather>> {
-        return new Promise(async resolve => {
-            const { full, lat, lon } = props;
+        const { full } = props;
+        let { lat, lon } = props;
 
+        // CHECK LOCATION
+        // if a lat and lon are not provided, get the user's location
+        if (!lat || !lon) {
+            const coords: GeolocationCoordinates = await LocationAPI.getPosition();
+            const { latitude, longitude } = coords;
+
+            // these could be 0 if there was an error getting the user's location
+            // we leave them at zero because we don't want to use the default
+            // provided by the API.
+            lat = latitude;
+            lon = longitude;
+        }
+
+        // fetch and return the weather data
+        return new Promise(async resolve => {
             // build the URL
             const URL = this.API_URL
                 // current doesn't provide the hourly, minutely, and daily data
@@ -25,6 +42,7 @@ class WeatherAPI {
 
             const token = this.API_KEY;
 
+            // ensures we have a valid URL and API key
             if (URL && token !== '') {
                 const data = await fetch(URL, {
                     method: 'GET',
@@ -37,7 +55,7 @@ class WeatherAPI {
                     .then(json => json)
                     .catch(_ => null);
 
-
+                // builds the response object, ensures we have data
                 const response = data ?
                     { data: data.data, status: data.statusCode, error: null } :
                     {
@@ -50,8 +68,10 @@ class WeatherAPI {
                 // TESTING ONLY SET A TIMEOUT FOR  SECONDS before resolving
                 // setTimeout(() => resolve(response), 10000);
 
+                // return the response
                 resolve(response);
             } else {
+                // If we made it this far the key is invalid
                 resolve({
                     status: 401, data: null, error: {
                         message:

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,7 @@
 export { default as suspender } from './suspender';
 export { default as WeatherAPI } from './APIs/weather/';
+export { default as LocationAPI } from './APIs/location/';
+
 
 
 
@@ -7,3 +9,4 @@ export { default as WeatherAPI } from './APIs/weather/';
 // export the interfaces
 export type { IWeather } from './APIs/weather/interfaces';
 export type { IApiResponse } from './APIs/interfaces';
+export type { ILocationAPI } from './APIs/location/interface';


### PR DESCRIPTION
data because it is more accurate. If the user denies location services with their browser, we fall back to IP address. If there is an error fetching the geo-location data, we alert the user to enable location services because we will default them to 0,0 or possibly random coordinates in the future. This closes issue #3.